### PR TITLE
docs(#20): Anthropic sponsorship pitch and contact research

### DIFF
--- a/docs/pitches/anthropic-contacts.md
+++ b/docs/pitches/anthropic-contacts.md
@@ -1,0 +1,78 @@
+# Anthropic Contacts & Programs — Sponsorship Research
+
+> Researched 2026-03-12
+
+## Best-Fit Program: Claude for Open Source
+
+**This is the primary target.** Anthropic offers 6 months of free Claude Max 20x ($200/mo tier) to qualifying open-source maintainers.
+
+- **Application URL:** https://claude.com/contact-sales/claude-for-oss
+- **Announced by:** Lydia Hallie ([@lydiahallie](https://x.com/lydiahallie)) — Claude Code team at Anthropic
+- **Standard criteria:** 5,000+ GitHub stars OR 1M+ monthly npm downloads + recent activity
+- **Flexibility clause:** Projects below thresholds may qualify if they represent "critical infrastructure relied upon by many systems" — applicants can explain their project's value
+
+### Why Thomas Qualifies (Flexibility Clause)
+
+Thomas's projects individually don't hit 5K stars, but the portfolio argument is strong:
+- **claude-gate** — biometric security for Claude Code (directly improves their product)
+- **OaP white paper** — security research addressing Anthropic's own threat model
+- **wasteland-orchestrator** — multi-agent orchestration for Claude Code
+- **neuroscript-rs** — built entirely with Claude, training frontier models
+
+The "critical infrastructure" clause + the security research angle is the strongest path.
+
+---
+
+## Key People
+
+### Alex Albert — Head of Developer Relations
+- **Role:** Leads all developer relations at Anthropic
+- **X/Twitter:** [@alexalbert__](https://x.com/alexalbert__)
+- **LinkedIn:** [linkedin.com/in/alex-albert](https://www.linkedin.com/in/alex-albert/)
+- **Website:** [alexalbert.me](https://alexalbert.me/)
+- **Location:** San Francisco
+- **Why contact:** He owns the developer ecosystem strategy. If anyone can champion a non-standard application, it's him.
+
+### Lydia Hallie — Claude Code Team / Developer Experience
+- **Role:** Announced and likely manages the Claude for Open Source program
+- **X/Twitter:** [@lydiahallie](https://x.com/lydiahallie)
+- **LinkedIn:** [linkedin.com/in/lydia-hallie](https://www.linkedin.com/in/lydia-hallie/)
+- **Website:** [lydiahallie.com](https://www.lydiahallie.com/)
+- **Background:** Former Head of DX at Bun, Staff DevRel at Vercel
+- **Why contact:** She's the face of the OSS program. A DM or tag on X could get attention.
+
+---
+
+## Alternative Programs (If OSS Program Doesn't Fit)
+
+### Claude Community Ambassadors
+- **URL:** https://claude.com/community/ambassadors
+- **Benefits:** Event funding, monthly API credits, pre-release features, private Slack with Anthropic teams
+- **Fit:** Medium. Thomas isn't primarily an event organizer, but the "builder community" angle could work.
+
+### Anthropic Fellows Program (2026 Cohorts: May & July)
+- **URL:** https://alignment.anthropic.com/2025/anthropic-fellows-program-2026/
+- **Benefits:** $3,850/week stipend, ~$15K/month compute, mentorship
+- **Research areas:** AI security, adversarial robustness, scalable oversight
+- **Fit:** Strong for the OaP/security research angle, but it's a 4-month full-time commitment. May not match Thomas's independent builder lifestyle.
+
+### Anthropic Startup Program
+- **URL:** https://claude.com/programs/startups
+- **Terms:** https://www.anthropic.com/startup-program-official-terms
+- **Fit:** If JARLF or WastelandWares is structured as a company, this could provide API credits.
+
+---
+
+## Contact Channels (Priority Order)
+
+1. **Apply directly** to Claude for Open Source: https://claude.com/contact-sales/claude-for-oss
+2. **DM or tag Lydia Hallie** on X with a brief thread about the portfolio
+3. **DM Alex Albert** on X or LinkedIn — frame it as ecosystem builder feedback
+4. **Email sales@anthropic.com** — formal inquiry referencing the OSS program
+5. **Email press@anthropic.com** — if framing as a story about neurodivergent developer success
+
+## Recommended Strategy
+
+**Two-pronged approach:**
+1. Submit the formal application through the Claude for Open Source portal, emphasizing the flexibility clause and the security research / ecosystem builder narrative
+2. Simultaneously reach out to Lydia Hallie on X (she's responsive to OSS community) with a concise thread showing the portfolio — she can likely flag the application internally

--- a/docs/pitches/anthropic-sponsorship-draft.md
+++ b/docs/pitches/anthropic-sponsorship-draft.md
@@ -1,0 +1,136 @@
+# Anthropic Sponsorship Pitch — Draft
+
+> For: Claude for Open Source program application + direct outreach
+> Date: 2026-03-12
+
+---
+
+## Version 1: Formal Application (Claude for Open Source Portal)
+
+Use this text when submitting through https://claude.com/contact-sales/claude-for-oss
+
+---
+
+**Name:** Thomas Quick
+**GitHub:** [github.com/severeon](https://github.com/severeon) / [github.com/WastelandWares](https://github.com/WastelandWares)
+**Projects:** claude-gate, neuroscript-rs, wasteland-orchestrator, OaP white paper, JARLF
+
+**Why I'm applying under the flexibility clause:**
+
+My projects individually don't hit 5K stars — I'm an independent developer, not a VC-backed org. But I think the portfolio tells a story Anthropic might find interesting.
+
+I'm a neurodivergent developer who used Claude Code to build an entire ecosystem over the past several months:
+
+- **neuroscript-rs** — A neural architecture composition language in Rust. I designed and implemented the language, compiler, and runtime entirely with Claude as my pair programmer. I'm now using it to build and train frontier-level models — tasks that take minutes instead of hours or days.
+
+- **claude-gate** — Open-source biometric permission gating for Claude Code. Adds hardware security to agentic workflows. Active development, v0.8.
+
+- **OaP (Opacity as Policy)** — A published white paper on security for agentic shell execution. It directly addresses the threat model Anthropic faces with tools like Claude Code — the idea that opacity itself can be a security mechanism when agents execute shell commands.
+
+- **wasteland-orchestrator** — Multi-agent orchestration for Claude Code. Manages concurrent Claude agents with role-based personas, worktree isolation, and a real-time game-like dashboard.
+
+- **JARLF** — A commercial product (Android biometric authentication for macOS) being built entirely on the Claude toolchain. Real revenue pipeline, not a toy project.
+
+All of this is open source. All of it was built with Claude.
+
+I'm not asking for investment or a partnership. I'm asking to keep building. A Claude Max subscription ($200/month) lets me continue doing what I'm already doing — building tools that make Claude better for everyone, publishing security research relevant to your threat model, and shipping real products on your platform.
+
+This is already a success story. I'd like to keep writing it.
+
+— Thomas Quick
+GitHub: severeon / WastelandWares
+
+---
+
+## Version 2: X/Twitter Thread (Tag @lydiahallie)
+
+For reaching out directly on X. Post as a thread:
+
+---
+
+**Tweet 1:**
+Hey @lydiahallie — applying for Claude for Open Source under the flexibility clause. My repos don't have 5K stars (yet), but here's what I built with Claude Code in the last few months: 🧵
+
+**Tweet 2:**
+🧠 neuroscript-rs — A neural architecture composition language in Rust. Designed the language, built the compiler, now training frontier models with it. All with Claude as pair programmer.
+
+**Tweet 3:**
+🔒 claude-gate — Biometric permission gating for Claude Code. Hardware security for agentic workflows. Because if Claude is running shell commands, maybe a fingerprint should be involved.
+
+**Tweet 4:**
+📄 Published the OaP (Opacity as Policy) white paper — security research on agentic shell execution that directly addresses Anthropic's threat model.
+
+**Tweet 5:**
+🤖 wasteland-orchestrator — Multi-agent orchestration for Claude Code. Concurrent agents, role-based personas, worktree isolation, game-like dashboard. It's how I manage my dev org.
+
+**Tweet 6:**
+All open source. All built with Claude. I'm a neurodivergent independent dev who hyperfocused on this for months and built an entire ecosystem.
+
+The ask: keep the Claude Max subscription so I can keep building tools that make Claude better for everyone. Application submitted through the portal. 🙏
+
+---
+
+## Version 3: Email (If Needed)
+
+For sales@anthropic.com or direct outreach. More formal but still authentic.
+
+---
+
+**Subject:** Claude for Open Source — Independent Ecosystem Builder Application
+
+Hi,
+
+I'm Thomas Quick, an independent developer applying for the Claude for Open Source program. I wanted to provide some additional context beyond the application form.
+
+Over the past several months, I've used Claude Code to build what I think is a fairly unusual portfolio:
+
+**The Language:** neuroscript-rs — a neural architecture composition language in Rust. I designed and implemented the compiler and runtime with Claude as my pair programmer. I'm now using it to build and train frontier-level models in minutes instead of hours.
+
+**The Security Research:** I published the OaP (Opacity as Policy) white paper on security for agentic shell execution. It directly addresses the threat model Anthropic faces with Claude Code — the argument that opacity itself functions as a security policy when AI agents execute commands.
+
+**The Tools:**
+- claude-gate — biometric permission gating for Claude Code (open source, v0.8)
+- wasteland-orchestrator — multi-agent orchestration for Claude Code
+- meeting-scribe — AI transcription with Obsidian integration
+
+**The Product:** JARLF — a commercial Android biometric auth product for macOS, being built entirely on the Claude toolchain.
+
+**The Organization:** WastelandWares — a full development org with game-like agent dashboard, CI/CD, and automated workflows, all orchestrated through Claude.
+
+Everything is open source on GitHub under [severeon](https://github.com/severeon) and [WastelandWares](https://github.com/WastelandWares).
+
+I'm a neurodivergent developer. Claude Code turned what could have been scattered hyperfocus into shipped projects. That's a real story about what your tools do for people.
+
+My individual repos don't hit the 5,000-star threshold — I'm one person, not a team with a marketing budget. But I believe the portfolio falls under the flexibility clause as ecosystem infrastructure. I'm not just using Claude — I'm building the tools that make Claude safer and more capable for other developers.
+
+The ask is simple: a Claude Max subscription so I can keep building.
+
+Thank you for considering it.
+
+Thomas Quick
+GitHub: [severeon](https://github.com/severeon) / [WastelandWares](https://github.com/WastelandWares)
+
+---
+
+## Artifacts to Link
+
+Include these in any application or outreach:
+
+| Project | URL | Relevance |
+|---------|-----|-----------|
+| neuroscript-rs | github.com/severeon/neuroscript-rs | Built entirely with Claude |
+| claude-gate | github.com/WastelandWares/claude-gate | Security tooling for Claude Code |
+| OaP White Paper | (link to published paper) | Security research, Anthropic's threat model |
+| wasteland-orchestrator | github.com/WastelandWares/wasteland-orchestrator | Multi-agent Claude orchestration |
+| JARLF | github.com/severeon/jarlf | Commercial product on Claude toolchain |
+| meeting-scribe | github.com/severeon/meeting-scribe | Productivity tool built with Claude |
+
+---
+
+## Notes for Thomas
+
+1. **Apply through the portal first** (https://claude.com/contact-sales/claude-for-oss) — use Version 1 as the application text
+2. **Same day or next day**, post the X thread tagging Lydia Hallie — she announced the program and is responsive
+3. **If no response in a week**, send Version 3 to sales@anthropic.com
+4. **Don't undersell it.** The flexibility clause exists for exactly this situation. Critical infrastructure doesn't just mean npm packages — security research and developer tooling for their own product counts.
+5. **The neurodivergent angle is genuine and powerful.** Don't lean on it as a sympathy play — lean on it as proof that Claude Code is an equalizer. That's the story Anthropic wants to tell.


### PR DESCRIPTION
## Summary
- Researched Anthropic programs: Claude for Open Source (best fit), Community Ambassadors, Fellows Program, Startup Program
- Identified key contacts: Alex Albert (Head of DevRel), Lydia Hallie (Claude Code team, announced OSS program)
- Drafted three pitch versions: formal application, X/Twitter thread, and email
- Recommended two-pronged strategy: formal application + direct outreach to Lydia Hallie

## Deliverables
- `docs/pitches/anthropic-contacts.md` — programs, contacts, strategy
- `docs/pitches/anthropic-sponsorship-draft.md` — pitch drafts + tactical notes

## Key Finding
The **Claude for Open Source** program has a flexibility clause for projects below the 5K star threshold that represent "critical infrastructure." Security tooling (claude-gate, OaP paper) and developer ecosystem tools (wasteland-orchestrator) fit this framing.

Closes tquick/wasteland-infra#20

🤖 Generated with [Claude Code](https://claude.com/claude-code)