### PR TITLE
docs: phase 4.5 documentation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - systemd service file for Linux runner persistence
 - macOS LaunchAgent plist for MacBook runner persistence
 - Comprehensive README with setup instructions and workflow documentation
+- WastelandWares brand identity documentation and Astro site with brand guidelines
+- Whitepapers site with Object-as-Property (OaP) paper
+- Anthropic sponsorship pitch and contact research documentation
+- GitHub Actions workflow to mirror main branch to Gitea (supports dual-host CI/CD)
 
 ### Changed
 - `claude-breakdown.yaml`: Filter on `needs-breakdown` label instead of firing on all label events
 - `claude-breakdown.yaml`: Improved prompt template with sub-issues, dependency ordering, and acceptance criteria
 - `claude-breakdown.yaml`: Auto-remove `needs-breakdown` label after successful breakdown
+- Main site updated to reference brand identity and whitepapers sites
+- GitHub mirror workflow provides real-time synchronization to Gitea instance

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Infrastructure-as-code for wastelandwares.com services.
 
+This repository manages the core infrastructure, CI/CD pipelines, and documentation sites for the WastelandWares ecosystem:
+
+- **Main Site** (`wastelandwares.com`): Project overview and landing page
+- **Brand Identity Site**: WastelandWares brand guidelines, visual identity, and design system documentation
+- **Whitepapers Site**: Academic papers including Object-as-Property (OaP) research
+- **Gitea Instance**: Self-hosted Git and CI/CD at localhost:3003
+- **GitHub Mirror**: Real-time synchronization between GitHub and Gitea (both serve as source)
+
 ## Gitea Actions
 
 ### Workflows
@@ -89,3 +97,18 @@ cp /path/to/wasteland-infra/.gitea/workflows/claude-review.yaml .gitea/workflows
 ```
 
 Workflows auto-detect project type, so no per-project configuration is needed.
+
+## GitHub Mirror Workflow
+
+The wasteland-infra repository is mirrored between GitHub and Gitea for dual-host CI/CD support:
+
+- **Primary Host**: GitHub (WastelandWares/wasteland-infra)
+- **Mirror Host**: Gitea (localhost:3003)
+- **Synchronization**: GitHub Actions workflow pushes main branch changes to Gitea in real-time
+
+This setup allows:
+- Local development and testing via Gitea CI/CD runners
+- Open-source visibility on GitHub
+- Flexible CI/CD execution across both platforms
+
+Both repositories receive updates immediately, enabling development teams to work with their preferred platform.


### PR DESCRIPTION
Documentation updates reflecting phase 4.5 development:

- WastelandWares brand identity and Astro site
- Whitepapers site with Object-as-Property paper
- Anthropic sponsorship pitch and contact research
- GitHub mirror workflow for dual-host CI/CD

Updates CHANGELOG.md and README.md to document these additions and the expanded project scope.